### PR TITLE
Allow to run the app with USE_MAVLINK and without /dev/serial0

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ Preparing SD Card for GS from pre-built image: [/doc/building_gs_image.md](/doc/
 
 Or building GS image : [/doc/building_gs_image.md](/doc/building_gs_image.md)
 
+Or building and running the Ground Station application on a Fedora Linux desktop (no Raspberry Pi required): [/doc/building_gs_fedora.md](/doc/building_gs_fedora.md)
+
 STL files for 3D printing enclosure on Thingiverse: https://www.thingiverse.com/thing:6624580
 
 ## Ground Station Variant 1: Single rtl8812au

--- a/doc/building_gs_fedora.md
+++ b/doc/building_gs_fedora.md
@@ -1,0 +1,28 @@
+# Building Ground Station app to run on a Fedora Linux desktop
+
+The Ground Station application can run on a desktop Linux (no Raspberry Pi required). This manual explains how to install and run the GS app on Fedora Linux.
+
+We will assume you are using a dedicated RTL8812AU WiFi adapter on interface `wlp0s20f0u1`.
+
+* Install [rtl8812au driver](https://github.com/svpcom/rtl8812au/).
+* Request NetworkManager to do not manage your adapter:
+```
+nmcli dev set wlp0s20f0u1 managed no
+```
+* Install dependencies:
+```
+sudo yum install SDL2-devel turbojpeg-devel freetype-devel
+```
+* Download the GS code:
+```
+git clone -b release --recursive https://github.com/RomanLut/esp32-cam-fpv
+```
+* Build the app:
+```
+cd esp32-cam-fpv/gs
+make -j4
+```
+* Launch GS:
+```
+sudo ./gs -rx wlp0s20f0u1 -tx wlp0s20f0u1
+```


### PR DESCRIPTION
Right now in order to compile the app on a desktop you need to comment out `#define USE_MAVLINK` in the `main.h`. That does not feel user-friendly. Let's add a few checks and make UART optional so anyone can compile a working version of GS without making any changes in code.