### PR TITLE
Add build firmware action

### DIFF
--- a/air_firmware_esp32cam/.github/workflows/build_firmware.yml
+++ b/air_firmware_esp32cam/.github/workflows/build_firmware.yml
@@ -1,0 +1,38 @@
+name: Build Firmware
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        project: [air_firmware_esp32cam, air_firmware_esp32s3sense, air_firmware_esp32s3sense_ov5640]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        pip install platformio
+
+    - name: Build firmware
+      run: |
+        platformio run -d ${{ matrix.project }}
+
+    - name: Upload firmware binaries
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.project }}-firmware
+        path: ${{ matrix.project }}/.pio/build/${{ matrix.project }}/*.bin


### PR DESCRIPTION
Add a GitHub Actions workflow to build firmware on each commit to the master branch.

* Create a new workflow file `build_firmware.yml` in the `.github/workflows/` directory.
* Trigger the workflow on each commit to the master branch.
* Define jobs to build `air_firmware_esp32cam`, `air_firmware_esp32s3sense`, and `air_firmware_esp32s3sense_ov5640` projects.
* Produce firmware binaries as artefacts for each project.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/RomanLut/hx-esp32-cam-fpv?shareId=3d834690-800f-4413-be89-393e7cfda750).